### PR TITLE
Fix exam event dispatch

### DIFF
--- a/src/main/java/com/example/studentmanagementsystem/course/service/ExamService.java
+++ b/src/main/java/com/example/studentmanagementsystem/course/service/ExamService.java
@@ -31,7 +31,7 @@ public class ExamService {
         if (entity.getId() == null) {
             log.info("enitty가 null입니다.");
         }
-        eventPublisher.publishEvent(entity);
+        eventPublisher.publishEvent(new EventCreateEntity(entity));
         return entity;
     }
 }

--- a/src/test/java/com/example/studentmanagementsystem/grade/GradeServiceTest.java
+++ b/src/test/java/com/example/studentmanagementsystem/grade/GradeServiceTest.java
@@ -133,6 +133,14 @@ class GradeServiceTest {
     }
 
     @Test
+    void testExamEventCreatesGrade(){
+        examService.createExamEntity(course, student, 80.0, 40);
+        Optional<GradeEntity> grade = gradeRepository.findByCourseAndStudent(course, student);
+        assertTrue(grade.isPresent());
+        assertEquals(32.0, grade.get().getGrade());
+    }
+
+    @Test
     @Transactional
     void testCreateGradeAndUpdateGrade() {
 


### PR DESCRIPTION
## Summary
- fire `EventCreateEntity` when creating an exam so grade listener triggers
- add unit test covering exam event listener

## Testing
- `./gradlew test` *(fails: unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6840061c5abc83289d02589397aabf57